### PR TITLE
fix: Do not replace an existing configuration file

### DIFF
--- a/tasks/noarch.yml
+++ b/tasks/noarch.yml
@@ -3,5 +3,4 @@
 - name: Copy Telegraf configuration file
   copy:
     dest: /etc/telegraf/telegraf.conf
-    force: false
     src: '{{ telegraf_conf }}'

--- a/tasks/noarch.yml
+++ b/tasks/noarch.yml
@@ -1,12 +1,7 @@
 ---
 
-- name: Check if the Telegraf config exists
-  stat:
-    path: /etc/telegraf/telegraf.conf
-  register: response
-
-- name: Copy Telegraf config (if not exists)
+- name: Copy Telegraf configuration file
   copy:
     dest: /etc/telegraf/telegraf.conf
+    force: false
     src: '{{ telegraf_conf }}'
-  when: not response.stat.exists


### PR DESCRIPTION
This pull request removes the task that checked for the existence of the Telegraf configuration file. By default, the [`copy`](https://docs.ansible.com/ansible/latest/modules/copy_module.html) module checks for the existence of a file on the remote host and replaces it if the contents of the local file are different.