### PR TITLE
style: Remove white space before colons [skip ci]

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,15 +21,15 @@ lint:
 platforms:
   - image: centos/systemd
     name: centos-7
-    << : *docker_options
+    <<: *docker_options
 
   - image: geerlingguy/docker-ubuntu1404-ansible
     name: ubuntu-1404
-    << : *docker_options
+    <<: *docker_options
 
   - image: geerlingguy/docker-ubuntu1604-ansible
     name: ubuntu-1604
-    << : *docker_options
+    <<: *docker_options
 provisioner:
   lint:
     name: ansible-lint


### PR DESCRIPTION
Galaxy warns about the white space before the colon in the Molecule configuration file:

```
===== LINTING ROLE: telegraf =====
yamllint Warnings:
./molecule/default/molecule.yml:24:7: [error] too many spaces before colon (colons)
./molecule/default/molecule.yml:28:7: [error] too many spaces before colon (colons)
./molecule/default/molecule.yml:32:7: [error] too many spaces before colon (colons)
ansible-lint OK.
```